### PR TITLE
Inform portage that xbmc-addon-libshairplay was renamed

### DIFF
--- a/profiles/updates/1Q-2015
+++ b/profiles/updates/1Q-2015
@@ -1,1 +1,2 @@
 move media-tv/xbmc media-tv/kodi
+move media-plugins/xbmc-addon-libshairplay media-plugins/kodi-addon-libshairplay


### PR DESCRIPTION
Updating with FEATURES="collision-protect" fails presently because we forgot to inform portage about this addon being renamed. I also bumped the version to incorporate the latest bug fixes.
